### PR TITLE
Remove extra space for ChargeState localized variables

### DIFF
--- a/Sources/TeslaKit/Structures/ChargeState.swift
+++ b/Sources/TeslaKit/Structures/ChargeState.swift
@@ -229,11 +229,11 @@ extension ChargeState {
     }
     
     public var localizedChargeLimitSoc: String {
-        String(self.chargeLimitSoc)+" %"
+        String(self.chargeLimitSoc)+"%"
     }
     
     public var localizedBatteryLevel: String {
-        String(format:"%.0f", self.batteryLevel*1)+" %"
+        String(format:"%.0f", self.batteryLevel*1)+"%"
     }
     
     public func localizedBatteryRange(distanceUnit: DistanceUnit) -> String {


### PR DESCRIPTION
* Remove extra space for ChargeState localized variables
* Previously: `75 %` Now: `75%`.